### PR TITLE
Now not clobbering width if found in g:figletOpts.

### DIFF
--- a/autoload/FIGlet.vim
+++ b/autoload/FIGlet.vim
@@ -28,7 +28,7 @@ function! <SID>RunFIGlet(text, opts, width, font, fontdir) "{{{
 	endif
 	
 	" set the width to &textwidth or default
-	if exists('s:overrideWidth') 
+	if exists('s:overrideWidth') || opts =~ '-w'
 		let width = ''
 	elseif '' != a:width
 		let width = '-w ' . a:width


### PR DESCRIPTION
Small fix to detect existence of -w option in g:figletOpts, and if set not to override it.